### PR TITLE
fix: allow referrer for external links

### DIFF
--- a/src/components/NextLink.tsx
+++ b/src/components/NextLink.tsx
@@ -15,7 +15,7 @@ export const NextLinkUnstyled = forwardRef(function NextLinkUnstyled(
     <a
       ref={ref}
       href={href}
-      rel={!isUrlRelative(href) ? "noopener noreferrer" : undefined}
+      rel={!isUrlRelative(href) ? "noopener" : undefined}
       {...props}
     />
   );

--- a/src/components/SidebarLayout/SidebarContent.tsx
+++ b/src/components/SidebarLayout/SidebarContent.tsx
@@ -95,7 +95,7 @@ export function SidebarContent() {
 function SidebarLink({ isExternal, ...props }: LinkProps) {
   return (
     <Link
-      rel={isExternal ? "noopener noreferrer" : undefined}
+      rel={isExternal ? "noopener" : undefined}
       color="blue.600"
       textDecoration="underline"
       {...props}

--- a/src/components/ToolLinkList.tsx
+++ b/src/components/ToolLinkList.tsx
@@ -25,7 +25,7 @@ export function ToolLinkList({
           m={1}
           as="a"
           href={tool.websiteUrl}
-          rel="noopener noreferrer"
+          rel="noopener"
           rightIcon={
             <Box w={5}>
               <ArrowTopRightOnSquareIcon />

--- a/src/pages/[tool].tsx
+++ b/src/pages/[tool].tsx
@@ -207,12 +207,11 @@ function ExampleCard({ example }: ExampleCardProps) {
       p={4}
       bgColor="gray.50"
       borderRadius="lg"
-      as="div"
       display="flex"
       flexDirection="column"
       justifyContent="flex-end"
       href={example.url}
-      rel="noopener noreferrer"
+      rel="noopener"
       transition="0.2s"
       cursor="pointer"
       _hover={{


### PR DESCRIPTION
We'd like sites we link to to know we're sending users to them. So this removes the `noreferrer` attribute from links -- I've confirmed the `referer` header is sent when clicking on links.

I also fixed a bug where we were using `div`s for the example links.