### PR TITLE
Datalore can be self-hosted

### DIFF
--- a/src/notebookTools.tsx
+++ b/src/notebookTools.tsx
@@ -713,7 +713,7 @@ export const notebookTools = {
     websiteUrl: "https://datalore.jetbrains.com/",
     features: {
       setupManaged: [{ type: "yes", setupTime: "minutes" }],
-      setupSelfHost: [{ type: "no" }],
+      setupSelfHost: [{ type: "yes" }],
 
       featuresJupyterCompatible: [{ type: "yes" }],
       featuresLanguages: [{ type: "jupyterLanguages" }],


### PR DESCRIPTION
https://www.jetbrains.com/help/datalore/datalore-enterprise.html#installation-process-overview